### PR TITLE
Setup code coverage with mocha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ data/*
 npm-debug.log
 mongod*
 run_mongod.bat
+help
+add
+coverage

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.0.1",
   "description": "Application used to enable voting on stories in a asynchronous way",
   "main": "bin/server.js",
-  "engines" : { "node" : ">=6.0.0" },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "scripts": {
-    "test": "cross-env NODE_ENV=test mocha -R spec test/*/*.spec.js",
+    "test": "cross-env NODE_ENV=test istanbul cover _mocha -R spec test/*/*.spec.js",
     "start": "node bin/server.js",
     "debug": "node debug bin/server.js",
     "cucumber": "cross-env NODE_ENV=test ./node_modules/.bin/cucumberjs"
@@ -39,6 +41,7 @@
     "chai-http": "^3.0.0",
     "cucumber": "^1.3.1",
     "database-cleaner": "^1.1.0",
+    "istanbul": "^0.4.5",
     "mocha": "^3.1.2",
     "sinon": "^1.17.6",
     "supertest": "^1.1.0"


### PR DESCRIPTION
- Generate coverage data in `coverage` directory.
- Display coverage summary below tests.

<img width="653" alt="screen shot 2016-11-15 at 10 56 58" src="https://cloud.githubusercontent.com/assets/459813/20303213/569ce03a-ab22-11e6-835b-dd723219d3c8.png">

This closes #58