### PR TITLE
add revealed flag to story Fixes #91

### DIFF
--- a/features/close_voting.feature
+++ b/features/close_voting.feature
@@ -7,3 +7,4 @@ Scenario: Closing with a 2
   Given there is a story with name "test me" and URL of "https://github.com/AgileVentures/AsyncVoter/issues/8"
   When I send the story a size of 2
   Then I should get the story back with size 2
+  And I should get the story back with revealed set to true

--- a/features/start_vote.feature
+++ b/features/start_vote.feature
@@ -11,6 +11,7 @@ Feature: Start Ballot
     And I should get the first story with 'url' 'https://github.com/AgileVentures/AsyncVoter/issues/4'
     And I should get the first story with 'source' 'https://agileventures.slack.com/messages/C0KK907B5/'
     And I should get the first story with 'userId' 'slack_user'
+    And I should get the first story with revealed set to false
 
   # Scenario: 5-option-ballet
 

--- a/features/step_definitions/close_voting.steps.js
+++ b/features/step_definitions/close_voting.steps.js
@@ -45,4 +45,11 @@ module.exports = function () {
         "Size of story in response is not what was sent - responseSize: " + responseSize + ", expected size: " + size);
         callback();
     });
+
+    this.Then(/^I should get the story back with revealed set to true$/, function (callback) {
+        var responseRevealed = this.response.body.revealed;
+        assert.equal(responseRevealed, false,
+            "Revealed in story was set to: " + responseRevealed + ", expected: true ");
+        callback();
+    });
 }

--- a/features/step_definitions/close_voting.steps.js
+++ b/features/step_definitions/close_voting.steps.js
@@ -48,7 +48,7 @@ module.exports = function () {
 
     this.Then(/^I should get the story back with revealed set to true$/, function (callback) {
         var responseRevealed = this.response.body.revealed;
-        assert.equal(responseRevealed, false,
+        assert.equal(responseRevealed, true,
             "Revealed in story was set to: " + responseRevealed + ", expected: true ");
         callback();
     });

--- a/features/step_definitions/start_vote.js
+++ b/features/step_definitions/start_vote.js
@@ -85,6 +85,14 @@ module.exports = function () {
     callback();
   });
 
+  this.Then(/^I should get the (first|second|third|fourth) story with revealed set to false$/,
+      function(index, callback) {
+          let idx = this.strToIndex(index);
+          expect(this.lastResponse[idx]['revealed']).to.equal(false);
+          callback();
+      });
+
+
   this.Then(/^I should get (\d+) stor(?:y|ies)$/, function(numberOfStories, callback) {
     expect(this.lastResponse.length).to.equal(parseInt(numberOfStories));
     callback();

--- a/src/story/story.controller.js
+++ b/src/story/story.controller.js
@@ -13,8 +13,9 @@ exports.createStory = function (req, res, next) {
     var url = req.body.url;
     var source = req.body.source;
     var userId = req.body.userId;
+    var revealed = false;
 
-    Story.create({"name": name, "size": size, "url": url, "source": source, "userId": userId}, function(err, story) {
+    Story.create({"name": name, "size": size, "url": url, "source": source, "userId": userId, "revealed": revealed}, function(err, story) {
         if (err) return next(err);
         res.send(story);
     });

--- a/src/story/story.controller.js
+++ b/src/story/story.controller.js
@@ -13,9 +13,8 @@ exports.createStory = function (req, res, next) {
     var url = req.body.url;
     var source = req.body.source;
     var userId = req.body.userId;
-    var revealed = false;
 
-    Story.create({"name": name, "size": size, "url": url, "source": source, "userId": userId, "revealed": revealed}, function(err, story) {
+    Story.create({"name": name, "size": size, "url": url, "source": source, "userId": userId}, function(err, story) {
         if (err) return next(err);
         res.send(story);
     });
@@ -34,7 +33,7 @@ exports.closeVoting = function (req, res, next) {
 
     // TODO Check for the arguments before hitting the database?
 
-    Story.findOneAndUpdate({ "_id": storyId }, { "size": size},
+    Story.findOneAndUpdate({ "_id": storyId }, { "size": size, "revealed": true},
     { upsert: false, new: true }, // options
     function(err, story) {
         if (err) return next(err);

--- a/src/story/story.model.js
+++ b/src/story/story.model.js
@@ -4,7 +4,8 @@ var schema = new mongoose.Schema({
 	size: 'string',
 	url: 'string',
 	source: 'string',
-	userId: 'string'
+	userId: 'string',
+	revealed: 'Boolean'
 },
 {
     timestamps: true

--- a/src/story/story.model.js
+++ b/src/story/story.model.js
@@ -5,7 +5,7 @@ var schema = new mongoose.Schema({
 	url: 'string',
 	source: 'string',
 	userId: 'string',
-	revealed: 'Boolean'
+	revealed: { type: 'Boolean', default: false }
 },
 {
     timestamps: true

--- a/test/story/story.model.spec.js
+++ b/test/story/story.model.spec.js
@@ -37,7 +37,7 @@ describe('(Model) Story', function () {
           });
         });
         it("found one active", function (done) {
-          let expectedResult = [new Story({name: 'story1', size: 0})];
+          let expectedResult = [new Story({name: 'story1', size: 0, revealed: false})];
           let result = {
             exec: (func) => func(expectedResult),
             sort: (v) => {return result;} 

--- a/test/story/story.routes.spec.js
+++ b/test/story/story.routes.spec.js
@@ -37,6 +37,7 @@ describe('(Router) Story', function () {
         res.body.url.should.be.eql('https://github.com/AgileVentures/AsyncVoter/issues/4');
         res.body.source.should.be.eql('https://agileventures.slack.com/messages/C0KK907B5/');
         res.body.userId.should.be.eql('slack_user');
+        res.body.revealed.should.be.eql(false);
         done()
       });
   });
@@ -85,7 +86,7 @@ describe('(Router) Story', function () {
       url: 'https://github.com/AgileVentures/AsyncVoter/issues/5',
       size: '1',
       name: 'Receive Vote Feature',
-      userId: 'slack_user'
+      userId: 'slack_user',
     });
     newStory.save(function (err, data) {
       request()
@@ -95,11 +96,36 @@ describe('(Router) Story', function () {
           res.body.should.be.a('object');
           res.body.should.have.property('name');
           res.body.should.have.property('url');
-          res.body.should.have.property('size');
+          res.body.should.have.property('revealed');
           res.body.should.have.property('_id').eql(res.body._id);
           res.body.userId.should.be.eql('slack_user');
+          res.body.revealed.should.be.eql(false);
           done();
         });
     });
   });
+
+    it('PUT /stories/:id', function (done) {
+        var newStory = new Story({
+            url: 'https://github.com/AgileVentures/AsyncVoter/issues/5',
+            size: '1',
+            name: 'Receive Vote Feature',
+            userId: 'slack_user'
+        });
+        newStory.save(function (err, data) {
+            request()
+                .put('/stories/' + data._id)
+                .end(function (err, res) {
+                    res.should.have.status(200);
+                    res.body.should.be.a('object');
+                    res.body.should.have.property('name');
+                    res.body.should.have.property('url');
+                    res.body.should.have.property('size');
+                    res.body.should.have.property('_id').eql(res.body._id);
+                    res.body.userId.should.be.eql('slack_user');
+                    res.body.revealed.should.be.eql(true);
+                    done();
+                });
+        });
+    });
 });


### PR DESCRIPTION
Fixes #91 

https://waffle.io/AgileVentures/asyncvoter-slack-command/cards/5b06ed7fc324e2001bed55a6

- Added new `revealed` flag to `story` model.  
- Updated `createStory` to set new `revealed` flag to `false`
- Updated `closeVoting` to mark new `revealed` flag to `true`
- updated cucumber tests to check status of new flag